### PR TITLE
restore object3D world position @TGA-025

### DIFF
--- a/src/animation/AnimationWorld.js
+++ b/src/animation/AnimationWorld.js
@@ -17,13 +17,11 @@ export const AnimationWorld = ({
   let accumulatedAnimationTime = 0;
   let startAnimationTime = 0;
   // Position
-  let positionFlag;
   const vectorInterpolant = {};
   let accumulatedDistance = 0;
   let positionMap;
   // Quaterion
   let quaternionTrackTimes = [];
-  let quaternionFlag;
   let quaternionMap;
   let yRadians = 0;
   const quaternionInterpolant = {};
@@ -38,30 +36,19 @@ export const AnimationWorld = ({
   }
 
   const playClipAction = ({ clipName, deltaSeconds }) => {
-    //positionFlag = 0;
-   // quaternionFlag = 0;
-   // if (positionMap.has(clipName) === false && quaternionMap.has(clipName) === false) return;
     activeTrackName = clipName;
     startAnimationTime = deltaSeconds;
     accumulatedAnimationTime = 0;
-    // If clip has world position tracks
-   // if (positionMap.has(clipName) === true) {
-      //const { times } = positionMap.get(clipName);
-      positionTrackTimes = positionMap.get(clipName).times;
-      accumulatedDistance = 0;
-
-      quaternionTrackTimes = quaternionMap.get(clipName).times;
-      startQuat.copy(worldMesh.quaternion);
-
-    
+    positionTrackTimes = positionMap.get(clipName).times;
+    accumulatedDistance = 0;
+    quaternionTrackTimes = quaternionMap.get(clipName).times;
+    startQuat.copy(worldMesh.quaternion);
   }
 
 
   const update = (deltaSeconds) => {
-  //  if (positionFlag < 1 && quaternionFlag < 1) return;
     accumulatedAnimationTime += deltaSeconds;
     const timeOffset = accumulatedAnimationTime - startAnimationTime;
-    // position track
     for (let idx = 1, nTracks = positionTrackTimes.length; idx < nTracks; idx++) {
       if (positionTrackTimes[idx - 1] < timeOffset && positionTrackTimes[idx] > timeOffset) {
           const [x, y, z] = vectorInterpolant[activeTrackName].interpolate_(idx, positionTrackTimes[idx - 1], timeOffset, positionTrackTimes[idx]);
@@ -73,7 +60,6 @@ export const AnimationWorld = ({
           break;
       }
     }
-    // quaternion track
     for (let idx = 1, nTracks = quaternionTrackTimes.length; idx < nTracks; idx++) {
       if (quaternionTrackTimes[idx - 1] < timeOffset && quaternionTrackTimes[idx] > timeOffset) {
         const [x, y, z, w] = quaternionInterpolant[activeTrackName].interpolate_(idx, quaternionTrackTimes[idx - 1], timeOffset, quaternionTrackTimes[idx]);

--- a/src/models/AnimatedModel.js
+++ b/src/models/AnimatedModel.js
@@ -17,12 +17,18 @@ export function AnimatedModel({
   const mesh = new THREE.Group();
   mesh.matrixAutoUpdate = true;
   mesh.visible = false;
+  // MESH DEBUG
+  const geometry = new THREE.BoxGeometry( .2, .2, .2 ); 
+  const material = new THREE.MeshBasicMaterial( {color: 0x00ff00} ); 
+  const cube = new THREE.Mesh( geometry, material );
+  mesh.add(cube);
   // ANIMATION HANDLER
   let animation;
   // SCRIPT PLAYER
   let scriptPlayer;
 
-  
+
+
   // LOAD MODEL
   fbxLoader.load(assetPath, (object) => {
     object.scale.multiplyScalar(meshScaler)


### PR DESCRIPTION
Imported model has anchor tracks removed and assigned to world anchor parent object. Removing position track from object3D resulted in off-center rotation point. Instead of removing position track, its values are set to zero.